### PR TITLE
Make registerAdapter non-static to avoid potential leaks

### DIFF
--- a/saripaar-tests/src/main/java/com/mobsandgeeks/saripaar/tests/ui/CustomMultipleViewDataAdaptersActivity.java
+++ b/saripaar-tests/src/main/java/com/mobsandgeeks/saripaar/tests/ui/CustomMultipleViewDataAdaptersActivity.java
@@ -117,7 +117,7 @@ public class CustomMultipleViewDataAdaptersActivity extends Activity
                 default:
                     throw new RuntimeException("This should never happen.");
             }
-            Validator.registerAdapter(FloatLabeledEditText.class, viewDataAdapter);
+            mValidator.registerAdapter(FloatLabeledEditText.class, viewDataAdapter);
         }
     }
 

--- a/saripaar-tests/src/main/java/com/mobsandgeeks/saripaar/tests/ui/CustomViewDataAdapterActivity.java
+++ b/saripaar-tests/src/main/java/com/mobsandgeeks/saripaar/tests/ui/CustomViewDataAdapterActivity.java
@@ -92,7 +92,7 @@ public class CustomViewDataAdapterActivity extends Activity
     @Override
     public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         if (isChecked) {
-            Validator.registerAdapter(FloatLabeledEditText.class,
+            mValidator.registerAdapter(FloatLabeledEditText.class,
                 new ViewDataAdapter<FloatLabeledEditText, Boolean>() {
 
                     @Override

--- a/saripaar/src/main/java/com/mobsandgeeks/saripaar/Validator.java
+++ b/saripaar/src/main/java/com/mobsandgeeks/saripaar/Validator.java
@@ -124,8 +124,8 @@ public class Validator {
     private static final Registry SARIPAAR_REGISTRY = new Registry();
 
     // Holds adapter entries that are mapped to corresponding views.
-    private static final
-            Map<Class<? extends View>, HashMap<Class<?>, ViewDataAdapter>> REGISTERED_ADAPTERS =
+    private final
+            Map<Class<? extends View>, HashMap<Class<?>, ViewDataAdapter>> mRegisteredAdaptersMap =
                     new HashMap<Class<? extends View>, HashMap<Class<?>, ViewDataAdapter>>();
 
     // Attributes
@@ -204,15 +204,15 @@ public class Validator {
      * @param <VIEW>  The {@link android.view.View} type.
      * @param <DATA_TYPE>  The {@link com.mobsandgeeks.saripaar.adapter.ViewDataAdapter} type.
      */
-    public static <VIEW extends View, DATA_TYPE> void registerAdapter(
+    public <VIEW extends View, DATA_TYPE> void registerAdapter(
             final Class<VIEW> viewType, final ViewDataAdapter<VIEW, DATA_TYPE> viewDataAdapter) {
         assertNotNull(viewType, "viewType");
         assertNotNull(viewDataAdapter, "viewDataAdapter");
 
-        HashMap<Class<?>, ViewDataAdapter> dataTypeAdapterMap = REGISTERED_ADAPTERS.get(viewType);
+        HashMap<Class<?>, ViewDataAdapter> dataTypeAdapterMap = mRegisteredAdaptersMap.get(viewType);
         if (dataTypeAdapterMap == null) {
             dataTypeAdapterMap = new HashMap<Class<?>, ViewDataAdapter>();
-            REGISTERED_ADAPTERS.put(viewType, dataTypeAdapterMap);
+            mRegisteredAdaptersMap.put(viewType, dataTypeAdapterMap);
         }
 
         // Find adapter's data type
@@ -599,7 +599,7 @@ public class Validator {
         // If we are unable to find a Saripaar stock adapter, check the registered adapters
         if (dataAdapter == null) {
             HashMap<Class<?>, ViewDataAdapter> dataTypeAdapterMap =
-                    REGISTERED_ADAPTERS.get(viewFieldType);
+                    mRegisteredAdaptersMap.get(viewFieldType);
             dataAdapter = dataTypeAdapterMap != null
                     ? dataTypeAdapterMap.get(adapterDataType)
                     : null;


### PR DESCRIPTION
Convert `Validator.registerAdapter` to be non-static method.
This helps to avoid leaking Context which is really easy when using static version of `regsiterAdapter` (just passing an anonymous class created inside an Activity will introduce a leak).

Fixes issue #97 

I have run all the tests after this changed - ALL PASS