### PR TITLE
Added support library to support support fagment too

### DIFF
--- a/saripaar/build.gradle
+++ b/saripaar/build.gradle
@@ -33,6 +33,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:support-annotations:23.1.1'
+    compile 'com.android.support:support-v4:23.1.1'
 }
 
 apply from: '../gradle-mvn-push.gradle'

--- a/saripaar/src/main/java/com/mobsandgeeks/saripaar/Validator.java
+++ b/saripaar/src/main/java/com/mobsandgeeks/saripaar/Validator.java
@@ -172,6 +172,11 @@ public class Validator {
             Activity activity = ((Fragment) controller).getActivity();
             mValidationContext = new ValidationContext(activity);
         }
+        else if(controller instanceof android.support.v4.app.Fragment){
+            Activity activity = (Activity) ((android.support.v4.app.Fragment) controller).getContext();
+            mValidationContext = new ValidationContext(activity);
+        }
+
         // Else, lazy init ValidationContext in #getRuleAdapterPair(Annotation, Field)
         // or void #put(VIEW, QuickRule<VIEW>) by obtaining a Context from one of the
         // View instances.


### PR DESCRIPTION
Add an additional "if" to ask if the "controller" was of the type "support" fragment, in cases where the "native fragment" is not used, doing this it is possible to do the validations also in this class fragment, and I added the additional dependency of support v4, I am using it locally in my project and it has not given me problems, and I extended the forms by handling it with a better user experience