### PR TITLE
Fix ragunathjawahar/android-saripaar#226

### DIFF
--- a/saripaar/src/main/java/com/mobsandgeeks/saripaar/rule/DigitsRule.java
+++ b/saripaar/src/main/java/com/mobsandgeeks/saripaar/rule/DigitsRule.java
@@ -32,7 +32,7 @@ public class DigitsRule extends AnnotationRule<Digits, String> {
         int integer = mRuleAnnotation.integer();
         int fraction = mRuleAnnotation.fraction();
 
-        String digitsRegex = String.format("(\\d{0,%d})(\\.\\d{1,%d})?", integer, fraction);
+        String digitsRegex = String.format(Locale.US, "(\\d{0,%d})(\\.\\d{1,%d})?", integer, fraction);
         return digits.matches(digitsRegex);
     }
 }


### PR DESCRIPTION
If the default locale is used, Regex compilation may fail if the default locale's numerals are not 0123456789.